### PR TITLE
add google kubernetes engine examples

### DIFF
--- a/google-kubernetes-engine/README.md
+++ b/google-kubernetes-engine/README.md
@@ -1,0 +1,61 @@
+# Deploy Go web app in Kubernetes
+
+## Create the Docker image
+
+First, we need to containerize our previous webserver application to be able to run it in Kubernetes. We will need a `Dockerfile` 
+to instruct how we want to build it. Once it's created, we can run:
+
+```bash
+cd app
+docker build -t webserver .
+```
+
+We can see the generated image by running:
+
+```bash
+docker image ls
+---
+webserver     latest    d94f50a32c7d   11 seconds ago   292MB
+```
+
+And we will need to push it to a repository. In my case I will use Docker Hub. For this, we will need to rename the image:
+
+```bash
+docker tag d94f50a32c7d docker.io/arnausenserrich/webserver:v1
+---
+arnausenserrich/webserver   latest    d94f50a32c7d   8 minutes ago   292MB
+```
+
+And push it to the repository:
+
+```bash
+docker push docker.io/arnausenserrich/webserver:v1
+```
+
+## Deploy to Kubernetes
+
+We could just use `kubectl` comands to run this image in Kubernetes, but let's create a deployment to easily manage it. Let's apply it:
+
+```bash
+kubectl apply -f deployment.yaml
+```
+
+Next step is create a service, so all the endpoints can be accessible from inside the cluster with a fixed fqdn:
+
+```bash
+kubectl apply -f service.yaml
+```
+
+Now we can also expose it, in our case as load balancer service, so it can be accessible from the Internet:
+
+```bash
+kubectl apply -f service.yaml
+```
+
+Wait few seconds so the load balancer is created and get the public IP:
+
+```bash
+kubectl get svc pub-webserver --output jsonpath='{.status.loadBalancer.ingress[0].ip}'
+```
+
+Now this application is accessible publicly.

--- a/google-kubernetes-engine/app/Dockerfile
+++ b/google-kubernetes-engine/app/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.21-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Copy the application source code
+COPY . ./
+
+# Build the application binary
+RUN go build -o /webserver
+
+# Expose the port
+EXPOSE 8080
+
+# Set the command to run the application
+CMD ["/webserver"]

--- a/google-kubernetes-engine/app/go.mod
+++ b/google-kubernetes-engine/app/go.mod
@@ -1,0 +1,3 @@
+module webserver
+
+go 1.21

--- a/google-kubernetes-engine/app/webserver.go
+++ b/google-kubernetes-engine/app/webserver.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
+
+const port = 8080
+
+func indexHandler(w http.ResponseWriter, r *http.Request) {
+	// Get the hostname
+	hostname, err := os.Hostname()
+	if err != nil {
+		http.Error(w, "Error getting hostname", http.StatusInternalServerError)
+		return
+	}
+
+	// Get request headers
+	userAgent := r.Header.Get("User-Agent")
+
+	// Formulate the response
+	response := fmt.Sprintf("Hostname: %s\nUser-Agent: %s", hostname, userAgent)
+
+	// Write the response
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(response))
+}
+
+func healthzHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+}
+
+func main() {
+	// Print a startup message
+	fmt.Println("Server starting...")
+
+	// Set up the handler
+	http.HandleFunc("/", indexHandler)
+	http.HandleFunc("/healthz", healthzHandler)
+
+	// Start the server
+	fmt.Printf("Starting HTTP server at port %d\n", port)
+	if err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil); err != nil {
+		fmt.Fprintf(os.Stderr, "Error starting server: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/google-kubernetes-engine/deployment.yaml
+++ b/google-kubernetes-engine/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: go-web
+  labels:
+    app: go-web
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: go-web
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: go-web
+        version: v1
+    spec:
+      containers:
+      - name: productpage
+        image: docker.io/arnausenserrich/webserver:v1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+          limits:
+            memory: "128Mi"
+            cpu: "500m"

--- a/google-kubernetes-engine/lb-service.yaml
+++ b/google-kubernetes-engine/lb-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pub-webserver
+spec:
+  selector:
+    app: go-web
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  externalTrafficPolicy: Local
+  type: LoadBalancer

--- a/google-kubernetes-engine/service.yaml
+++ b/google-kubernetes-engine/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webserver
+  labels:
+    app: go-web
+    service: webserver
+spec:
+  ports:
+  - port: 8080
+    name: http
+  selector:
+    app: go-web


### PR DESCRIPTION
Add examples to add the application previously created in Compute Engine to Google Kubernetes Engine.